### PR TITLE
Fix set_debug_output

### DIFF
--- a/lib/net/ptth.rb
+++ b/lib/net/ptth.rb
@@ -31,7 +31,7 @@ class Net::PTTH
 
     @host, @port = info.host, info.port || options.fetch(:port, 80)
     @keep_alive = options.fetch(:keep_alive, false)
-    set_debug_output = StringIO.new
+    self.set_debug_output = StringIO.new
   end
 
   # Public: Mimics Net::HTTP set_debug_output

--- a/lib/net/ptth.rb
+++ b/lib/net/ptth.rb
@@ -40,10 +40,11 @@ class Net::PTTH
   #
   def set_debug_output=(output)
     @debug_output = output
-    Celluloid.logger = if output.is_a?(String)
-                         ::Logger.new(output)
-                       else
+
+    Celluloid.logger = if output.respond_to?(:debug)
                          output
+                       else
+                         ::Logger.new(output)
                        end
   end
 


### PR DESCRIPTION
`StringIO` isn't `is_a?(String)` so this wasn't working as expected, and the `set_debug_output` usage in the initialize was inadvertently setting an unused local variable instead of calling the setter method. Tested with then `ENV[HTTP_DEBUG]` variable that is currently in place.