### PR TITLE
Boot Celluloid in Tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,9 @@ require "minitest/pride"
 require "minitest/autorun"
 require "net/ptth"
 
+class Minitest::Spec
+  def setup
+    Celluloid.shutdown
+    Celluloid.boot
+  end
+end


### PR DESCRIPTION
For now this was required for me to get the tests running on the master branch without Celluloid complaining that the thread pool had not been started. I am not sure how this was working previously? Celluloid offers some `autostart` or `test` requires, but neither of them seemed to work.