### PR TITLE
Fix IncomingRequest #to_env

### DIFF
--- a/lib/net/ptth/incoming_request.rb
+++ b/lib/net/ptth/incoming_request.rb
@@ -8,7 +8,7 @@ class Net::PTTH
         "REQUEST_METHOD" => method,
       }
 
-      env.tap { |h| h["CONTENT_LENGTH"] = body.length if !body.nil? }
+      env["CONTENT_LENGTH"] = body.length unless body.nil?
 
       env.merge!(headers) if headers
     end

--- a/lib/net/ptth/incoming_request.rb
+++ b/lib/net/ptth/incoming_request.rb
@@ -11,6 +11,8 @@ class Net::PTTH
       env["CONTENT_LENGTH"] = body.length unless body.nil?
 
       env.merge!(headers) if headers
+
+      env
     end
   end
 end


### PR DESCRIPTION
The HTTP 101 switch protocols upgrade request doesn't need a body or content type; when testing without the header I found that requests without headers were ending up with a nil `#to_env` which was confusing Cuba et al. when `app.call(env)`-ing.