### PR TITLE
Configure Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,23 @@
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.7
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Max: 80

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    ast (2.4.2)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     celluloid-io (0.15.0)
@@ -17,18 +18,39 @@ GEM
     cuba (3.1.0)
       rack
     http_parser.rb (0.6.0.beta.2)
+    json (2.6.2)
     minitest (4.4.0)
     nio4r (2.5.8)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
+    rainbow (3.1.1)
     rake (10.1.0)
+    regexp_parser (2.6.0)
+    rexml (3.2.5)
+    rubocop (1.37.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.22.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.23.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
     sinatra (1.3.6)
       rack (~> 1.4)
       rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     tilt (1.4.1)
     timers (1.1.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby
@@ -38,6 +60,7 @@ DEPENDENCIES
   minitest (~> 4.4.0)
   net-ptth!
   rake
+  rubocop (~> 1)
   sinatra (~> 1.3.3)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,3 +39,6 @@ DEPENDENCIES
   net-ptth!
   rake
   sinatra (~> 1.3.3)
+
+BUNDLED WITH
+   2.3.24

--- a/net-ptth.gemspec
+++ b/net-ptth.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("minitest", "~> 4.4.0")
   s.add_development_dependency("cuba", "~> 3.1.0")
+  s.add_development_dependency("rubocop", "~> 1")
   s.add_development_dependency("sinatra", "~> 1.3.3")
 end


### PR DESCRIPTION
This installs and configures Rubocop with a reasonable set of defaults based on the existing code. It does not attempt to fix any linter warnings at this time.