### PR TITLE
Remove Rack Dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     net-ptth (0.0.17)
       celluloid-io (>= 0.15.0)
       http_parser.rb (>= 0.6.0.beta.2)
-      rack (>= 1.4.5)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,12 +55,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cuba (~> 3.1.0)
+  cuba (< 4)
   minitest (~> 4.4.0)
   net-ptth!
   rake
   rubocop (~> 1)
-  sinatra (~> 1.3.3)
+  sinatra (< 4)
 
 BUNDLED WITH
    2.3.24

--- a/lib/net/ptth.rb
+++ b/lib/net/ptth.rb
@@ -1,5 +1,4 @@
 require "uri"
-require "rack"
 require "net/http"
 require "logger"
 

--- a/net-ptth.gemspec
+++ b/net-ptth.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_dependency("rack",           ">= 1.4.5")
   s.add_dependency("celluloid-io",   ">= 0.15.0")
   s.add_dependency("http_parser.rb", ">= 0.6.0.beta.2")
 

--- a/net-ptth.gemspec
+++ b/net-ptth.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency("http_parser.rb", ">= 0.6.0.beta.2")
 
   s.add_development_dependency("minitest", "~> 4.4.0")
-  s.add_development_dependency("cuba", "~> 3.1.0")
+  s.add_development_dependency("cuba", "< 4")
   s.add_development_dependency("rubocop", "~> 1")
-  s.add_development_dependency("sinatra", "~> 1.3.3")
+  s.add_development_dependency("sinatra", "< 4")
 end


### PR DESCRIPTION
We don't actually depend on rack in the gem (we only adhere to a rack-esque API in some spots), so this can go. Also, the tests only have a pretty loose dependency on sinatra and cuba usage (only the most basic API is used,) so I have loosened those constraints as well. I know these are boring updates, but the good stuff is coming soon!